### PR TITLE
Initial attempt at API documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,71 @@
+# FWMT Legacy Gateway API
+This page documents the Fieldwork Management Tool (FWMT) Gateway API endpoints. Apart from the Service Information endpoint, all these endpoints are secured using HTTP basic authentication. All endpoints return an `HTTP 200 OK` status code except where noted otherwise.
+
+## Timestamps
+Where timestamps are used they should be in UTC and formatted according to ISO 8601 with a date and time component separated by a letter "T" and a letter "Z" suffix to indicate Zulu time (UTC) i.e. *YYYY-MM-DDTHH:MM:SSZ*. For example, 2018-04-24T19:31:25Z.
+
+## Error Handling
+All endpoints that accept HTTP POST requests may return any one of the HTTP error status codes below:
+
+* An `HTTP 400 Bad Request` is returned if the file name specified in the request does not match the file name format expected by the endpoint
+
+* An `HTTP 415 Unsupported Media Type` is returned upon receipt of a non-CSV file
+
+* An `HTTP 422 Unprocessable Entity` is returned for all other parsing errors
+
+* An `HTTP 500 Internal Server Error` is returned if the data could not be persisted by the gateway for whatever reason
+
+In addition to the HTTP error status code, a JSON error object will be returned in the HTTP response that provides additional information.
+
+### Example JSON Error Response
+```json
+{
+  "error": "Bad Request",
+  "exception": "uk.gov.ons.fwmt.gateway.domain.InvalidFilenameException",
+  "message": "Invalid filename",
+  "path": "/samples",
+  "status": 400,
+  "timestamp": "2018-04-24T19:44:32Z"
+}
+```
+
+## Service Information
+* `GET /info` will return information about this service, collated from when it was last built.
+
+### Example JSON Response
+```json
+{
+    "name": "fwmt-legacy-gateway",
+    "version": "1.0.0",
+    "origin": "git@github.com:ONSdigital/fwmt-legacy-gateway.git",
+    "commit": "e6891f890a4402e438918a5d261f0723f2838878",
+    "branch": "master",
+    "built": "2018-04-24T20:00:30Z"
+}
+```
+
+## Upload Sample and Allocation Data
+* `POST /samples` accepts a CSV file containing sample and allocation data as multi-part form data. The filename format must be *sample_&lt;survey_tla&gt;_&lt;timestamp&gt;.csv*
+
+### Example JSON Response
+```json
+{
+  "filename": "sample_GFF_2018-04-24T19:09:54Z.csv",
+  "rows": 5000
+}
+```
+
+The input filename is echoed back to the client upon a successful request, as is the number of rows within the CSV file that the gateway successfully persisted in its reception database table, prior to subsequent processing and transfer to the fieldwork management tool.
+
+## Upload Staff Data
+* `POST /staff` accepts a CSV file containing staff data as multi-part form data. The filename format must be *staff_&lt;timestamp&gt;.csv*
+
+### Example JSON Response
+```json
+{
+  "filename": "staff_GFF_2018-04-24T19:09:54Z.csv",
+  "rows": 750
+}
+```
+
+The input filename is echoed back to the client upon a successful request, as is the number of rows within the CSV file that the gateway successfully persisted in its reception database table, prior to subsequent processing and transfer to the fieldwork management tool.

--- a/API.md
+++ b/API.md
@@ -18,19 +18,7 @@ All endpoints that accept HTTP POST requests may return any one of the HTTP erro
 
 * An `HTTP 500 Internal Server Error` is returned if the data could not be persisted by the gateway for whatever reason
 
-In addition to the HTTP error status code, a JSON error object will be returned in the HTTP response that provides additional information.
-
-### Example JSON Error Response
-```json
-{
-  "error": "Bad Request",
-  "exception": "uk.gov.ons.fwmt.gateway.domain.InvalidFilenameException",
-  "message": "Invalid filename",
-  "path": "/samples",
-  "status": 400,
-  "timestamp": "2018-04-24T19:44:32Z"
-}
-```
+In addition to the HTTP error status code, a JSON error object will be returned in the HTTP response that provides additional information. See the individual endpoint documentation below for details of this error object.
 
 ## Service Information
 * `GET /info` will return information about this service, collated from when it was last built.
@@ -60,6 +48,27 @@ In addition to the HTTP error status code, a JSON error object will be returned 
 
 The input filename is echoed back to the client upon a successful request, as is the number of rows within the CSV file that the gateway successfully persisted in its reception database table, prior to subsequent processing and transfer to the fieldwork management tool.
 
+### Example JSON Error Response
+```json
+{
+  "error": "Unprocessable Entity",
+  "message": "File parsing errors occurred",
+  "path": "/samples",
+  "status": 422,
+  "timestamp": "2018-04-24T19:44:32Z",
+  "errors": [
+    {
+      "row": 4,
+      "exception": "org.hibernate.exception.ConstraintViolationException: Could not insert"
+    },
+    {
+      "row": 12,
+      "exception": "org.hibernate.exception.ConstraintViolationException: Duplicate entry"
+    }
+  ]
+}
+```
+
 ## Upload Staff Data
 * `POST /staff` accepts a CSV file containing staff data as multi-part form data. The filename format must be *staff_&lt;timestamp&gt;.csv*
 
@@ -72,3 +81,15 @@ The input filename is echoed back to the client upon a successful request, as is
 ```
 
 The input filename is echoed back to the client upon a successful request, as is the number of rows within the CSV file that the gateway successfully persisted in its reception database table, prior to subsequent processing and transfer to the fieldwork management tool.
+
+### Example JSON Error Response
+```json
+{
+  "error": "Bad Request",
+  "exception": "uk.gov.ons.fwmt.gateway.domain.InvalidFilenameException",
+  "message": "Invalid filename",
+  "path": "/staff",
+  "status": 400,
+  "timestamp": "2018-04-24T19:44:32Z"
+}
+```

--- a/API.md
+++ b/API.md
@@ -1,6 +1,9 @@
 # FWMT Legacy Gateway API
 This page documents the Fieldwork Management Tool (FWMT) Gateway API endpoints. Apart from the Service Information endpoint, all these endpoints are secured using HTTP basic authentication. All endpoints return an `HTTP 200 OK` status code except where noted otherwise.
 
+## Content Type
+Incoming requests must specify `text/csv` as the value of the HTTP `Content-Type` header.
+
 ## Timestamps
 Where timestamps are used they should be in UTC and formatted according to ISO 8601 with a date and time component separated by a letter "T" and a letter "Z" suffix to indicate Zulu time (UTC) i.e. *YYYY-MM-DDTHH:MM:SSZ*. For example, 2018-04-24T19:31:25Z.
 

--- a/README.md
+++ b/README.md
@@ -10,5 +10,8 @@ This repository contains the Fieldwork Management Tool (FWMT) Gateway for interf
     docker pull postgres:latest
     docker run -p 127:0.0.1:5432:5432 postgres
 
+## API
+See [API.md](https://github.com/ONSdigital/fwmt-legacy-gateway/blob/master/API.md) for API documentation.
+
 ## Copyright
 Copyright (C) 2018 Crown Copyright (Office for National Statistics)


### PR DESCRIPTION
Here's a starter for ten on the API documentation. A few notes:

- The JSON error response object is essentially what you get out the box with Spring Boot. It will need further work if we're going to get into providing row-level detail of errors, but I think that's too ambitious for May

- The `/info` service information endpoint is a standard pattern that all the RAS and RM microservices implement. It's not hard to do. I think it's worth the gateway being a good platform citizen by including it. It's useful for quickly seeing exactly which version of the code is running on a particular environment

- I made it `/samples` (plural) rather than the current `/sample` to follow the RESTful convention of plural resource names i.e. when you POST you're adding a new member to a collection. However, I made the POST requests return an HTTP 200 OK upon success, rather than 201 Created, because although we're modifying server-side state by writing rows into a database, strictly speaking we're not creating a new server-side resource that you can subsequently retrieve through a GET request. Typically a 201 response include a hyperlink to the new resource, which doesn't apply in this case